### PR TITLE
Fix prerequisites for recycling deep space loaders

### DIFF
--- a/process-deadlock-bridge.lua
+++ b/process-deadlock-bridge.lua
@@ -22,7 +22,7 @@ for _, color in pairs(belt_colors) do
 	table.insert(recipe_infos, {
 		recipe_name = "se-deep-space-transport-belt-loader-".. color,
 		entity_type = "loader-1x1",
-		technology_name = "deadlock-stacking-space-deep",
+		technology_name = "se-deep-space-transport-belt",
 		to_icon = "se-deep-space-transport-belt-loader-black",
 		no_percentage_test = is_base_entity,
 	})


### PR DESCRIPTION
If space-exploration, se-recycling-extras, deadlock-beltbox-loaders, and Deadlock-SE-Bridge are all loaded, **and** the `deadlock-enable-beltboxes` ("Enable Beltboxes") setting is disabled, se-recycling-extras will crash on load:
```
__se-recycling-extras__/data-functions.lua:152:no tech for se-deep-space-transport-belt-loader-blue
```
This is because `deadlock-stacking-space-deep` ("Naquium stacking") is the wrong technology prerequisite -- this tech is only added by Deadlock-SE-Bridge when beltboxes are enabled, and unlocks beltboxes (aka "crating") for deep space belts and certain deep-space tier items.

The correct prerequisite appears to be `se-deep-space-transport-belt` -- loaders are unlocked by this technology, so it stands to reason that it should unlock their recycling as well.